### PR TITLE
Various refactors and fixes to account-creation-service

### DIFF
--- a/account-creation-service/src/main.rs
+++ b/account-creation-service/src/main.rs
@@ -839,7 +839,7 @@ async fn create_account(
                         }))
                     }
                     _ => {
-                        tracing::error!("Transaction failed: {:?}", outcome.status);
+                        tracing::error!("Transaction failed. Status: {:?} Outcome: {:?}", outcome.status, outcome.transaction_outcome);
                         Ok(Json(CreateAccountResponse {
                             success: false,
                             message: format!("Transaction failed: {:?}", outcome.status),

--- a/account-creation-service/src/main.rs
+++ b/account-creation-service/src/main.rs
@@ -839,7 +839,11 @@ async fn create_account(
                         }))
                     }
                     _ => {
-                        tracing::error!("Transaction failed. Status: {:?} Outcome: {:?}", outcome.status, outcome.transaction_outcome);
+                        tracing::error!(
+                            "Transaction failed. Status: {:?} Outcome: {:?}",
+                            outcome.status,
+                            outcome.transaction_outcome
+                        );
                         Ok(Json(CreateAccountResponse {
                             success: false,
                             message: format!("Transaction failed: {:?}", outcome.status),
@@ -1521,22 +1525,18 @@ impl FromStr for AssetId {
                             format!("Invalid account id {contract_id}: {e}")
                         })?))
                     }
-                    ["nep245", contract_id, token_id] => {
-                        Ok(AssetId::Nep245(
-                            contract_id
-                                .parse()
-                                .map_err(|e| format!("Invalid account id {contract_id}: {e}"))?,
-                            token_id.to_string(),
-                        ))
-                    }
-                    ["nep171", contract_id, token_id] => {
-                        Ok(AssetId::Nep171(
-                            contract_id
-                                .parse()
-                                .map_err(|e| format!("Invalid account id {contract_id}: {e}"))?,
-                            token_id.to_string(),
-                        ))
-                    }
+                    ["nep245", contract_id, token_id] => Ok(AssetId::Nep245(
+                        contract_id
+                            .parse()
+                            .map_err(|e| format!("Invalid account id {contract_id}: {e}"))?,
+                        token_id.to_string(),
+                    )),
+                    ["nep171", contract_id, token_id] => Ok(AssetId::Nep171(
+                        contract_id
+                            .parse()
+                            .map_err(|e| format!("Invalid account id {contract_id}: {e}"))?,
+                        token_id.to_string(),
+                    )),
                     _ => Err(format!("Invalid asset id: {s}")),
                 }
             }
@@ -1761,7 +1761,7 @@ async fn check_otc_balances(state: &RelayerState, intear_dex: &AccountId, relaye
             .first()
             .expect("No private keys available");
 
-        let access_key = match state
+        let access_key = state
             .rpc_client
             .get_access_key(
                 state.relayer_id.clone(),
@@ -1769,17 +1769,14 @@ async fn check_otc_balances(state: &RelayerState, intear_dex: &AccountId, relaye
                 QueryFinality::Finality(Finality::None),
             )
             .await
-        {
-            Ok(key) => key,
-            Err(e) => {
+            .map_err(|e| {
                 tracing::error!(
                     "[{}] Failed to get access key for withdrawal: {}",
                     relayer_id,
                     e
                 );
-                return;
-            }
-        };
+            })
+            .unwrap();
 
         let block_hash = match state
             .rpc_client

--- a/account-creation-service/src/main.rs
+++ b/account-creation-service/src/main.rs
@@ -1513,38 +1513,33 @@ impl FromStr for AssetId {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "near" => Ok(AssetId::Near),
-            _ => match s.split_once(':') {
-                Some(("nep141", contract_id)) => {
-                    Ok(AssetId::Nep141(contract_id.parse().map_err(|e| {
-                        format!("Invalid account id {contract_id}: {e}")
-                    })?))
-                }
-                Some(("nep245", rest)) => {
-                    if let Some((contract_id, token_id)) = rest.split_once(':') {
+            _ => {
+                let parts: Vec<&str> = s.split(':').collect();
+                match parts.as_slice() {
+                    ["nep141", contract_id] => {
+                        Ok(AssetId::Nep141(contract_id.parse().map_err(|e| {
+                            format!("Invalid account id {contract_id}: {e}")
+                        })?))
+                    }
+                    ["nep245", contract_id, token_id] => {
                         Ok(AssetId::Nep245(
                             contract_id
                                 .parse()
                                 .map_err(|e| format!("Invalid account id {contract_id}: {e}"))?,
                             token_id.to_string(),
                         ))
-                    } else {
-                        Err(format!("Invalid asset id: {s}"))
                     }
-                }
-                Some(("nep171", rest)) => {
-                    if let Some((contract_id, token_id)) = rest.split_once(':') {
+                    ["nep171", contract_id, token_id] => {
                         Ok(AssetId::Nep171(
                             contract_id
                                 .parse()
                                 .map_err(|e| format!("Invalid account id {contract_id}: {e}"))?,
                             token_id.to_string(),
                         ))
-                    } else {
-                        Err(format!("Invalid asset id: {s}"))
                     }
+                    _ => Err(format!("Invalid asset id: {s}")),
                 }
-                _ => Err(format!("Invalid asset id: {s}")),
-            },
+            }
         }
     }
 }

--- a/account-creation-service/src/main.rs
+++ b/account-creation-service/src/main.rs
@@ -1031,7 +1031,7 @@ async fn swap_for_gas(
         amount_in: U128::from("0.3 NEAR".parse::<NearToken>().unwrap().as_yoctonear()),
         amount_out: U128::from(match inverse_route.estimated_amount {
             Amount::AmountIn(_) => unreachable!(),
-            Amount::AmountOut(amount) => amount / 10 * 9, // 10% fee
+            Amount::AmountOut(amount) => amount * 9 / 10, // 10% fee
         }),
         validity: OtcValidity {
             expiry: Some(OtcExpiryCondition::Timestamp {

--- a/account-creation-service/src/main.rs
+++ b/account-creation-service/src/main.rs
@@ -670,20 +670,16 @@ async fn create_account(
     let relayer_id = headers
         .get("x-relayer-id")
         .and_then(|h| h.to_str().ok())
-        .ok_or_else(|| {
-            (
-                StatusCode::BAD_REQUEST,
-                "Missing x-relayer-id header".to_string(),
-            )
-        })?;
+        .ok_or((
+            StatusCode::BAD_REQUEST,
+            "Missing x-relayer-id header".to_string(),
+        ))?;
 
     let configs = app_state.configs.read().await;
-    let config = configs.get(relayer_id).ok_or_else(|| {
-        (
-            StatusCode::NOT_FOUND,
-            format!("Relayer not found: {}", relayer_id),
-        )
-    })?;
+    let config = configs.get(relayer_id).ok_or((
+        StatusCode::NOT_FOUND,
+        format!("Relayer not found: {}", relayer_id),
+    ))?;
 
     check_account_creation_limit(&app_state, relayer_id, config.max_accounts_created_per_day)
         .await?;

--- a/account-creation-service/src/main.rs
+++ b/account-creation-service/src/main.rs
@@ -1778,22 +1778,19 @@ async fn check_otc_balances(state: &RelayerState, intear_dex: &AccountId, relaye
             })
             .unwrap();
 
-        let block_hash = match state
+        let block_hash = state
             .rpc_client
             .block(BlockReference::Finality(Finality::Final))
             .await
             .map(|block| block.header.hash)
-        {
-            Ok(hash) => hash,
-            Err(e) => {
+            .map_err(|e| {
                 tracing::error!(
                     "[{}] Failed to fetch block hash for withdrawal: {}",
                     relayer_id,
                     e
                 );
-                return;
-            }
-        };
+            })
+            .unwrap();
 
         let withdraw_action = Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "dex_call".to_string(),

--- a/account-creation-service/src/main.rs
+++ b/account-creation-service/src/main.rs
@@ -681,6 +681,14 @@ async fn create_account(
         format!("Relayer not found: {}", relayer_id),
     ))?;
 
+    // Validate payload before any operations
+    if config.factory.is_none() && !payload.account_id.is_sub_account_of(&config.relayer_id) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Account ID is not a subaccount of relayer ID".to_string(),
+        ));
+    }
+
     check_account_creation_limit(&app_state, relayer_id, config.max_accounts_created_per_day)
         .await?;
 
@@ -773,15 +781,7 @@ async fn create_account(
         nonce: access_key.nonce + 1,
         receiver_id: match state.factory {
             Some(factory) => factory,
-            None => {
-                if !payload.account_id.is_sub_account_of(&state.relayer_id) {
-                    return Err((
-                        StatusCode::BAD_REQUEST,
-                        "Account ID is not a subaccount of relayer ID".to_string(),
-                    ));
-                }
-                payload.account_id.clone()
-            }
+            None => payload.account_id.clone(),
         },
         block_hash: state
             .rpc_client

--- a/account-creation-service/src/main.rs
+++ b/account-creation-service/src/main.rs
@@ -20,7 +20,7 @@ use near_min_api::{
         near_crypto::{PublicKey, SecretKey},
     },
 };
-use rand::seq::SliceRandom;
+use rand::{Rng, seq::SliceRandom};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::serde_as;
 use std::{
@@ -693,16 +693,13 @@ async fn create_account(
         payload.account_id
     );
 
-    let (relayer_key, queue) = loop {
-        let key = state
-            .relayer_keys
-            .choose(&mut rand::thread_rng())
-            .expect("No private keys available");
-        let public_key = key.public_key();
-        if let Some(queue) = state.key_queues.get(&public_key) {
-            break (key.clone(), queue.clone());
-        }
-    };
+    let index = rand::thread_rng().gen_range(0..state.relayer_keys.len());
+    let relayer_key = state.relayer_keys[index].clone();
+    let public_key = relayer_key.public_key();
+    let queue = state
+        .key_queues
+        .get(&public_key)
+        .expect("Key missing from queues; this is a bug");
 
     let _guard = queue.lock().await;
 


### PR DESCRIPTION
Hey :)

Ive made a couple refractors to the account-creation-service with medium to low impact on functionality of the program. Please inform me of any dicrepancies.

## Changelog

1. **Simplify closure to direct tuple in error handling:** Simplify a closure-based error transformation to a direct tuple pattern for readability.

2. **Replace `choose` with `gen_range` for relayer key selection:** Improve random relayer key selection by using `gen_range` index-based approach for clearer intent.

3. **Validate subaccount ownership before processing account creation:** Add ownership validation to ensure only authorized requests are processed.

4. **Improve log output to include transaction outcome:** Enhance logging to include transaction execution results for better visibility.

5. **Adjust fee calculation to avoid integer truncation:** Fix fee calculation to prevent integer truncation and ensure accurate amounts.

6. **Replace nested `split_once` calls with a single `split(':')`:**  Simplify string parsing by replacing nested `split_once` chains with a single `split(':')`.

7. **Format tracing error log and simplify match blocks:** Reformat tracing error output and simplify match blocks for cleaner error handling.

8. **Replace match on block hash retrieval with `map_err` and `unwrap`:** Align block hash retrieval with the codebase's consistent error-handling style.
