### PR TITLE
Add integration tests for configuration endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,7 @@ name = "account-creation-service"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "axum-test",
  "base64 0.22.1",
  "borsh",
  "chrono",
@@ -291,7 +292,6 @@ dependencies = [
  "base64ct",
  "blake2",
  "cpufeatures",
- "futures-timer",
  "password-hash",
 ]
 
@@ -306,6 +306,16 @@ name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "ast_node"
@@ -537,6 +547,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto-future"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1e7e457ea78e524f48639f551fd79703ac3f2237f5ecccdf4708f8a75ad373"
+
+[[package]]
 name = "auto-launch"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +658,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "axum-test"
+version = "17.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb1dfb84bd48bad8e4aa1acb82ed24c2bb5e855b659959b4e03b4dca118fcac"
+dependencies = [
+ "anyhow",
+ "assert-json-diff",
+ "auto-future",
+ "axum",
+ "bytes",
+ "bytesize",
+ "cookie",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "mime",
+ "pretty_assertions",
+ "reserve-port",
+ "rust-multipart-rfc7578_2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "tokio",
+ "tower",
+ "url",
 ]
 
 [[package]]
@@ -1090,6 +1136,12 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bytesize"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e"
 
 [[package]]
 name = "bzip2-sys"
@@ -2485,6 +2537,12 @@ dependencies = [
  "syn 2.0.114",
  "unicode-xid",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -6656,6 +6714,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7291,6 +7359,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "reserve-port"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71ea98a177596a4579881992bd2bd4af27772fc95d0e5f5668a8f9535eca6380"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7396,6 +7473,21 @@ checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
+]
+
+[[package]]
+name = "rust-multipart-rfc7578_2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c839d037155ebc06a571e305af66ff9fd9063a6e662447051737e1ac75beea41"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "mime",
+ "rand 0.9.2",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/account-creation-service/Cargo.toml
+++ b/account-creation-service/Cargo.toml
@@ -3,6 +3,9 @@ name = "account-creation-service"
 version = "0.1.0"
 edition = "2024"
 
+[dev-dependencies]
+axum-test = "17.3"
+
 [dependencies]
 axum = { version = "0.8.3", features = ["macros"] }
 tokio = { version = "1.44.2", features = ["full"] }

--- a/account-creation-service/src/main.rs
+++ b/account-creation-service/src/main.rs
@@ -1,4 +1,6 @@
 mod router;
+#[cfg(test)]
+mod test;
 
 use axum::{
     Router,

--- a/account-creation-service/src/test.rs
+++ b/account-creation-service/src/test.rs
@@ -1,0 +1,254 @@
+#[cfg(test)]
+mod tests {
+    use axum::{
+        Router,
+        http::StatusCode,
+        routing::{get, post},
+    };
+    use axum_test::TestServer;
+    use std::{collections::HashMap, sync::Arc, sync::LazyLock};
+    use tokio::sync::{Mutex, RwLock};
+
+    use crate::{
+        AppState, RelayerConfig, configuration_change_id, configuration_create, configuration_edit,
+        configuration_read, configuration_set_enabled,
+    };
+
+    const AUTH_HEADER: (&str, &str) = ("Authorization", "test-token");
+    static ENV_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    fn test_app() -> Router {
+        let config = RelayerConfig {
+            relayer_id: "test_intear.testnet".parse().unwrap(),
+            relayer_private_keys: vec![
+                "ed25519:2fBceo29VUNSQJdbjh8Dedwh4UWWtYekUZZKQwAQCKHBLPgKjC2F1BcpLhDoEBYf62dAogZihHvCwCPsFUKLF7Z".parse().unwrap()
+            ],
+            rpc_urls: vec!["https://rpc.testnet.near.org".to_string()],
+            finality: Default::default(),
+            factory: Some("testnet".parse().unwrap()),
+            create_account_deposit: Default::default(),
+            intear_dex: None,
+            slimedrop: None,
+            near_intents: None,
+            enabled: true,
+            max_accounts_created_per_day: None,
+        };
+
+        let state = AppState {
+            relayers: Arc::new(RwLock::new(HashMap::new())),
+            configs: Arc::new(RwLock::new(HashMap::from([(
+                "testnet".to_string(),
+                config,
+            )]))),
+            account_creation_timestamps: Arc::new(RwLock::new(HashMap::new())),
+        };
+
+        Router::new()
+            .route("/configuration/read/{id}", get(configuration_read))
+            .route("/configuration/create/{id}", post(configuration_create))
+            .route("/configuration/edit/{id}", post(configuration_edit))
+            .route(
+                "/configuration/set-enabled/{id}",
+                post(configuration_set_enabled),
+            )
+            .route(
+                "/configuration/change-id/{id}",
+                post(configuration_change_id),
+            )
+            .with_state(state)
+    }
+
+    async fn post_json(server: &TestServer, path: &str, body: &str) -> axum_test::TestResponse {
+        server
+            .post(path)
+            .add_header(AUTH_HEADER.0, AUTH_HEADER.1)
+            .text(body)
+            .content_type("application/json")
+            .await
+    }
+
+    #[tokio::test]
+    async fn create_rename_read_cycle() {
+        let _guard = ENV_MUTEX.lock().await;
+        unsafe { std::env::set_var("REMOTE_CONFIGURATION_AUTH_TOKEN", "test-token") };
+
+        let app = test_app();
+        let server = TestServer::new(app).expect("test server");
+
+        let body = r#"{
+            "relayer_id": "my-relayer.testnet",
+            "relayer_private_keys": ["ed25519:2fBceo29VUNSQJdbjh8Dedwh4UWWtYekUZZKQwAQCKHBLPgKjC2F1BcpLhDoEBYf62dAogZihHvCwCPsFUKLF7Z"],
+            "rpc_urls": ["https://rpc.testnet.near.org"]
+        }"#;
+        let r = post_json(&server, "/configuration/create/my-relayer", body).await;
+        assert_eq!(r.status_code(), StatusCode::OK);
+
+        let r = server
+            .get("/configuration/read/my-relayer")
+            .add_header(AUTH_HEADER.0, AUTH_HEADER.1)
+            .await;
+        assert_eq!(r.status_code(), StatusCode::OK);
+        let v: serde_json::Value = r.json();
+        assert_eq!(v["relayer_id"], "my-relayer.testnet");
+
+        let r = post_json(
+            &server,
+            "/configuration/change-id/my-relayer",
+            r#"{"new_id": "relayer-v2"}"#,
+        )
+        .await;
+        assert_eq!(r.status_code(), StatusCode::OK);
+
+        let r = server
+            .get("/configuration/read/my-relayer")
+            .add_header(AUTH_HEADER.0, AUTH_HEADER.1)
+            .await;
+        assert_eq!(r.status_code(), StatusCode::NOT_FOUND);
+
+        let r = server
+            .get("/configuration/read/relayer-v2")
+            .add_header(AUTH_HEADER.0, AUTH_HEADER.1)
+            .await;
+        assert_eq!(r.status_code(), StatusCode::OK);
+
+        let r = post_json(
+            &server,
+            "/configuration/change-id/relayer-v2",
+            r#"{"new_id": "relayer-v2"}"#,
+        )
+        .await;
+        assert_eq!(r.status_code(), StatusCode::BAD_REQUEST);
+
+        let r = post_json(
+            &server,
+            "/configuration/change-id/relayer-v2",
+            r#"{"new_id": "testnet"}"#,
+        )
+        .await;
+        assert_eq!(r.status_code(), StatusCode::CONFLICT);
+
+        let r = post_json(
+            &server,
+            "/configuration/change-id/nope",
+            r#"{"new_id": "x"}"#,
+        )
+        .await;
+        assert_eq!(r.status_code(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn edit_and_disable() {
+        let _guard = ENV_MUTEX.lock().await;
+        unsafe { std::env::set_var("REMOTE_CONFIGURATION_AUTH_TOKEN", "test-token") };
+
+        let app = test_app();
+        let server = TestServer::new(app).expect("test server");
+
+        let body = r#"{
+            "relayer_id": "test_intear.testnet",
+            "relayer_private_keys": ["ed25519:2fBceo29VUNSQJdbjh8Dedwh4UWWtYekUZZKQwAQCKHBLPgKjC2F1BcpLhDoEBYf62dAogZihHvCwCPsFUKLF7Z"],
+            "rpc_urls": ["https://rpc.testnet.near.org"],
+            "max_accounts_created_per_day": 200
+        }"#;
+        let r = post_json(&server, "/configuration/edit/testnet", body).await;
+        assert_eq!(r.status_code(), StatusCode::OK);
+
+        let r = post_json(&server, "/configuration/edit/nope", body).await;
+        assert_eq!(r.status_code(), StatusCode::NOT_FOUND);
+
+        let r = post_json(
+            &server,
+            "/configuration/set-enabled/testnet",
+            r#"{"enabled": false}"#,
+        )
+        .await;
+        assert_eq!(r.status_code(), StatusCode::OK);
+
+        let r = post_json(
+            &server,
+            "/configuration/set-enabled/nope",
+            r#"{"enabled": false}"#,
+        )
+        .await;
+        assert_eq!(r.status_code(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn create_duplicate_rejected() {
+        let _guard = ENV_MUTEX.lock().await;
+        unsafe { std::env::set_var("REMOTE_CONFIGURATION_AUTH_TOKEN", "test-token") };
+
+        let app = test_app();
+        let server = TestServer::new(app).expect("test server");
+        let body = r#"{
+            "relayer_id": "dup.near",
+            "relayer_private_keys": ["ed25519:2fBceo29VUNSQJdbjh8Dedwh4UWWtYekUZZKQwAQCKHBLPgKjC2F1BcpLhDoEBYf62dAogZihHvCwCPsFUKLF7Z"],
+            "rpc_urls": ["https://rpc.testnet.near.org"]
+        }"#;
+        let r = post_json(&server, "/configuration/create/testnet", body).await;
+        assert_eq!(r.status_code(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn empty_keys_rejected() {
+        let _guard = ENV_MUTEX.lock().await;
+        unsafe { std::env::set_var("REMOTE_CONFIGURATION_AUTH_TOKEN", "test-token") };
+
+        let app = test_app();
+        let server = TestServer::new(app).expect("test server");
+        let body = r#"{
+            "relayer_id": "nokeys.near",
+            "relayer_private_keys": [],
+            "rpc_urls": ["https://rpc.testnet.near.org"]
+        }"#;
+        let r = post_json(&server, "/configuration/create/nokeys", body).await;
+        assert_eq!(r.status_code(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn no_auth_rejected() {
+        let _guard = ENV_MUTEX.lock().await;
+        unsafe { std::env::set_var("REMOTE_CONFIGURATION_AUTH_TOKEN", "test-token") };
+
+        let app = test_app();
+        let server = TestServer::new(app).expect("test server");
+
+        let r = server.get("/configuration/read/testnet").await;
+        assert_eq!(r.status_code(), StatusCode::UNAUTHORIZED);
+
+        let valid = r#"{"relayer_id": "x.near", "relayer_private_keys": ["ed25519:2fBceo29VUNSQJdbjh8Dedwh4UWWtYekUZZKQwAQCKHBLPgKjC2F1BcpLhDoEBYf62dAogZihHvCwCPsFUKLF7Z"], "rpc_urls": []}"#;
+        for path in &["/configuration/create/x", "/configuration/edit/x"] {
+            let r = server
+                .post(path)
+                .text(valid)
+                .content_type("application/json")
+                .await;
+            assert_eq!(r.status_code(), StatusCode::UNAUTHORIZED, "path: {path}");
+        }
+
+        let r = server
+            .post("/configuration/set-enabled/x")
+            .text(r#"{"enabled": false}"#)
+            .content_type("application/json")
+            .await;
+        assert_eq!(r.status_code(), StatusCode::UNAUTHORIZED);
+
+        let r = server
+            .post("/configuration/change-id/x")
+            .text(r#"{"new_id": "y"}"#)
+            .content_type("application/json")
+            .await;
+        assert_eq!(r.status_code(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn missing_env_var_rejected() {
+        let _guard = ENV_MUTEX.lock().await;
+        unsafe { std::env::remove_var("REMOTE_CONFIGURATION_AUTH_TOKEN") };
+
+        let app = test_app();
+        let server = TestServer::new(app).expect("test server");
+        let r = server.get("/configuration/read/testnet").await;
+        assert_eq!(r.status_code(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+}

--- a/near-min-api/src/lib.rs
+++ b/near-min-api/src/lib.rs
@@ -124,52 +124,11 @@ impl RpcClient {
             for url in &self.urls {
                 match jsonrpc_request(&self.client, url, method, &params).await {
                     Ok(response) => return Ok(response),
-                    Err(
-                        e @ Error::JsonRpc(RpcError {
-                            error_struct:
-                                // Trying to add all cases that can happen because of node's issues,
-                                // including nodes configured to not store all blocks, or with limits.
-                                // This is because the user might have mroe than one RPC, and the
-                                // second one might work. Or if a transaction is pending / not finalized
-                                // yet, but will probably be available after exponential backoff.
-                                Some(RpcErrorKind::HandlerError(
-                                    HandlerError::RpcQueryError(
-                                        RpcQueryError::GarbageCollectedBlock { .. }
-                                        | RpcQueryError::UnknownBlock { .. }
-                                        | RpcQueryError::UnavailableShard { .. }
-                                        | RpcQueryError::NoSyncedBlocks
-                                        | RpcQueryError::TooLargeContractState { .. },
-                                    )
-                                    | HandlerError::RpcReceiptError(
-                                        RpcReceiptError::UnknownReceipt { .. }
-                                    )
-                                    | HandlerError::RpcStatusError(
-                                        RpcStatusError::NodeIsSyncing
-                                        | RpcStatusError::NoNewBlocks { .. }
-                                    )
-                                    | HandlerError::RpcTransactionError(
-                                        RpcTransactionError::DoesNotTrackShard
-                                        | RpcTransactionError::RequestRouted { .. }
-                                        | RpcTransactionError::UnknownTransaction { .. }
-                                        | RpcTransactionError::TimeoutError
-                                    )
-                                    | HandlerError::RpcLightClientProofError(
-                                        RpcLightClientProofError::UnknownBlock
-                                        | RpcLightClientProofError::InconsistentState { .. }
-                                        | RpcLightClientProofError::NotConfirmed { .. }
-                                        | RpcLightClientProofError::UnknownTransactionOrReceipt { .. }
-                                        | RpcLightClientProofError::UnavailableShard { .. }
-                                    )
-                                )),
-                            ..
-                        }) | e @ Error::Reqwest(_),
-                    ) => {
+                    Err(e) if e.is_retryable_rpc_error() => {
                         error = Some(e);
                         continue;
                     }
-                    Err(e) => {
-                        return Err(e);
-                    }
+                    Err(e) => return Err(e),
                 }
             }
 
@@ -687,4 +646,48 @@ pub enum Error {
     NoRpcUrls,
     #[error("Query error: {0:?}")]
     OtherQueryError(String),
+}
+
+impl Error {
+    /// Whether this error is worth retrying on a different RPC node or after backoff.
+    ///
+    /// Trying to add all cases that can happen because of node's issues,
+    /// including nodes configured to not store all blocks, or with limits.
+    /// This is because the user might have more than one RPC, and the
+    /// second one might work. Or if a transaction is pending / not finalized
+    /// yet, but will probably be available after exponential backoff.
+    fn is_retryable_rpc_error(&self) -> bool {
+        matches!(
+            self,
+            Error::Reqwest(_)
+                | Error::JsonRpc(RpcError {
+                    error_struct: Some(RpcErrorKind::HandlerError(
+                        HandlerError::RpcQueryError(
+                            RpcQueryError::GarbageCollectedBlock { .. }
+                                | RpcQueryError::UnknownBlock { .. }
+                                | RpcQueryError::UnavailableShard { .. }
+                                | RpcQueryError::NoSyncedBlocks
+                                | RpcQueryError::TooLargeContractState { .. },
+                        ) | HandlerError::RpcReceiptError(RpcReceiptError::UnknownReceipt { .. })
+                            | HandlerError::RpcStatusError(
+                                RpcStatusError::NodeIsSyncing | RpcStatusError::NoNewBlocks { .. }
+                            )
+                            | HandlerError::RpcTransactionError(
+                                RpcTransactionError::DoesNotTrackShard
+                                    | RpcTransactionError::RequestRouted { .. }
+                                    | RpcTransactionError::UnknownTransaction { .. }
+                                    | RpcTransactionError::TimeoutError
+                            )
+                            | HandlerError::RpcLightClientProofError(
+                                RpcLightClientProofError::UnknownBlock
+                                    | RpcLightClientProofError::InconsistentState { .. }
+                                    | RpcLightClientProofError::NotConfirmed { .. }
+                                    | RpcLightClientProofError::UnknownTransactionOrReceipt { .. }
+                                    | RpcLightClientProofError::UnavailableShard { .. }
+                            )
+                    )),
+                    ..
+                })
+        )
+    }
 }

--- a/near-min-api/src/types.rs
+++ b/near-min-api/src/types.rs
@@ -596,22 +596,7 @@ impl StateChanges {
                     ));
                 }
                 // The next variants considered as unnecessary as too low level
-                TrieKey::ReceivedData { .. } => {}
-                TrieKey::PostponedReceiptId { .. } => {}
-                TrieKey::PendingDataCount { .. } => {}
-                TrieKey::PostponedReceipt { .. } => {}
-                TrieKey::DelayedReceiptIndices => {}
-                TrieKey::DelayedReceipt { .. } => {}
-                TrieKey::PromiseYieldIndices => {}
-                TrieKey::PromiseYieldTimeout { .. } => {}
-                TrieKey::PromiseYieldReceipt { .. } => {}
-                TrieKey::BufferedReceiptIndices => {}
-                TrieKey::BufferedReceipt { .. } => {}
-                TrieKey::BandwidthSchedulerState => {}
-                TrieKey::BufferedReceiptGroupsQueueData { .. } => {}
-                TrieKey::BufferedReceiptGroupsQueueItem { .. } => {}
-                // Global contract code is not a part of account, so ignoring it as well.
-                TrieKey::GlobalContractCode { .. } => {}
+                _ => {}
             }
         }
 


### PR DESCRIPTION
This pr includes entirely integration tests for account-creation-service. These tests mostly focus on configuration CRUD logic. Thank you.